### PR TITLE
Bugfix/issue 8

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,5 @@ OAUTH_TOKEN="oauth:exampleoauthtoken"
 CHANNEL="yourTwitchChannel"
 DELEGATION_TOKEN="exampledelegationkey"
 PREFIX="!"
+LEVEL_LIMIT_TYPE="active"
 LEVEL_LIMIT=0

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ This parameter controls how many levels a single person can submit. Set it to 0 
 
 `LEVEL_LIMIT=5`
 
+### Level Submission Limit Type
+This specifies how LEVEL_LIMIT (above) is applied.  It can be set to "session" (meaning that we limit the total number of levels each user can submit; once you've submitted X levels, you're done until the bot is reset) or "active" (meaning that we only limit the number of levels a user may have in the queue at one time; a user's level count then decreases when their level is played or if they !remove it)
+
+ LEVEL_LIMIT_TYPE="active"
+
 ### Results
 The final file should now look something like this: (**Note:** It does **not** matter what order the parameters are in)
 

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -83,20 +83,24 @@ class ShenaniBot {
       let response = "There aren't any levels in the queue!";
       return response;
     }
-    if (this.queue.length === 1) {
-      let response = "This is the only level in the queue!";
-      return response;
-    }
 
     this.rce.levelhead.bookmarks.remove(this.queue[0].levelId);
     this.queue.shift();
-    this.rce.levelhead.bookmarks.add(this.queue[0].levelId);
+    if (this.options.levelLimitType === 'active') {
+      this.users[this.queue[0].submittedBy].levelsSubmitted--;
+    }
+
+    if (this.queue.length === 0) {
+      let response = "The queue is now empty";
+      return response;
+    }
 
     let index = Math.round(Math.random() * (this.queue.length - 1));
     let randomLevel = this.queue[index];
     this.queue.splice(index, 1)
     this.queue.unshift(randomLevel);
 
+    this.rce.levelhead.bookmarks.add(this.queue[0].levelId);
     let response = `Random Level... Now playing ${this.queue[0].levelName}@${this.queue[0].levelId} submitted by ${this.queue[0].submittedBy}`;
     return response;
   }

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -61,15 +61,19 @@ class ShenaniBot {
       let response = "There aren't any levels in the queue!";
       return response;
     }
-    if (this.queue.length === 1) {
-      let response = "This is the only level in the queue!";
-      return response;
-    }
 
     this.rce.levelhead.bookmarks.remove(this.queue[0].levelId);
     this.queue.shift();
-    this.rce.levelhead.bookmarks.add(this.queue[0].levelId);
+    if (this.options.levelLimitType === 'active') {
+      this.users[this.queue[0].submittedBy].levelsSubmitted--;
+    }
 
+    if (this.queue.length === 0) {
+      let response = "The queue is now empty";
+      return response;
+    }
+
+    this.rce.levelhead.bookmarks.add(this.queue[0].levelId);
     let response = `Now playing ${this.queue[0].levelName}@${this.queue[0].levelId} submitted by ${this.queue[0].submittedBy}`;
     return response;
   }
@@ -151,6 +155,9 @@ class ShenaniBot {
           }
           
           this.queue.splice(i, 1);
+          if (this.options.levelLimitType === 'active') {
+            this.users[username].levelsSubmitted--;
+          }
 
           let response = `${level.levelName}@${level.levelId} was removed from the queue!`;
           return response;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,7 +8,8 @@ const streamer = process.env.STREAMER;
 const delegationToken = process.env.DELEGATION_TOKEN;
 
 const prefix = process.env.PREFIX || '!';
-const levelLimit = process.env.LEVEL_LIMIT || '!';
+const levelLimit = process.env.LEVEL_LIMIT || 0;
+const levelLimitType = (process.env.LEVEL_LIMIT_TYPE || 'active').toLocaleLowerCase();
 
 module.exports = {
   auth: {
@@ -20,6 +21,7 @@ module.exports = {
   },
   config: {
     prefix,
-    levelLimit
+    levelLimit,
+    levelLimitType
   }
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -9,7 +9,7 @@ const delegationToken = process.env.DELEGATION_TOKEN;
 
 const prefix = process.env.PREFIX || '!';
 const levelLimit = process.env.LEVEL_LIMIT || 0;
-const levelLimitType = (process.env.LEVEL_LIMIT_TYPE || 'active').toLocaleLowerCase();
+const levelLimitType = (process.env.LEVEL_LIMIT_TYPE || 'active').toLowerCase();
 
 module.exports = {
   auth: {


### PR DESCRIPTION
fixes #8 

This addresses eedefeed's concern by adding a configuration parameter which lets the streamer decide between the original behavior (just count !add commands; each user gets a limited # of levels until the bot is reset) and the new behavior (levels only count against the limit until they leave the queue due to !remove, !next, or !random)

There are a couple incidental bugfixes in the patch; most notably, !random would previously have reported the correct level in chat, but in most cases would have sent the wrong bookmark data to the LH API.