### PR TITLE
add permit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The bot stores a list of viewer-submitted levelcodes for you to play, and automa
 **Streamer Commands**  
 `!open` : Opens the queue for viewers to submit levels  
 `!close` : Closes the queue  
+`!permit [user name]` : Allows a user to add one level to the queue even if it is closed or they have reached the submission limit
 `!next` : Moves the queue forward a level  
 `!random` : Chooses a random level from the queue and puts it at the front of the queue to play
   

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -22,7 +22,7 @@ class ShenaniBot {
         case "close":
           return this.closeQueue();
         case "permit":
-          return this.permitUser(command[1].toLowerCase());
+          return command[1] ? this.permitUser(command[1].toLowerCase()) : "";
         case "next":
           return this.nextLevel();
         case "random":
@@ -32,7 +32,7 @@ class ShenaniBot {
 
     switch (command[0]) {
       case "add":
-        return this.addLevelToQueue(command[1], username);
+        return command[1] ? this.addLevelToQueue(command[1], username) : "";
       case "remove":
         return this.removeLevelFromQueue(command[1], username);
       case "queue":
@@ -62,6 +62,10 @@ class ShenaniBot {
   }
 
   permitUser(username) {
+    if (username[0] === "@") {
+      username = username.slice(1);
+    }
+
     let response;
     const user = this._getUser(username);
 


### PR DESCRIPTION
This adds a streamer command `!permit`, which allows a specific user to add a level even if the queue is closed and/or the user has reached the submission limit.

I've seen a few times that a streamer has a closed queue, but a new viewer arrives and the streamer wants to let that specific user submit a level.  If they open the queue, other users invariably try to "sneak" levels in.  The streamer can use !permit instead to prevent that problem.