### PR TITLE
Basic Twitch Chat Message Throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ This option controls how the `LEVEL_LIMIT` option works.  It can be set to `sess
 
 `LEVEL_LIMIT_TYPE="active"`
 
+### Twitch Message Throttling
+If you want to limit the rate at which the bot sends twitch chat messages, you can enable this option.  This can be useful to prevent an active chat (or potentially an attacker) from causeing the bot to spam or, in extreme cases, to be disconnected by Twitch anti-spam measures.
+
+`USE_THROTTLE="true"`
+
 ---
 ## Results
 The final file should now look something like this: (**Note:** It does **not** matter what order the parameters are in)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shenanibot-public",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,6 +11,11 @@
       "requires": {
         "axios": "^0.19.2"
       }
+    },
+    "@madelsberger/pausebuffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@madelsberger/pausebuffer/-/pausebuffer-1.0.0.tgz",
+      "integrity": "sha512-+p2dd5PkWOIivO3REnAShw+LLq40I1nAjjWz0xOdf4B0R1xxsoosbe1e33N61zdrp/1IpwLTeUZWmkqcW2mPfg=="
     },
     "ajv": {
       "version": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/platforms/twitch/index.js",
   "dependencies": {
     "@bscotch/rumpus-ce": "^1.2.0",
+    "@madelsberger/pausebuffer": "^1.0.0",
     "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "tmi.js": "^1.5.0"

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -10,6 +10,7 @@ const delegationToken = process.env.DELEGATION_TOKEN;
 const prefix = process.env.PREFIX || '!';
 const levelLimit = process.env.LEVEL_LIMIT || 0;
 const levelLimitType = (process.env.LEVEL_LIMIT_TYPE || 'active').toLowerCase();
+const useThrottle = (process.env.USE_THROTTLE || 'false').toLowerCase() === 'true';
 
 module.exports = {
   auth: {
@@ -22,6 +23,7 @@ module.exports = {
   config: {
     prefix,
     levelLimit,
-    levelLimitType
+    levelLimitType,
+    useThrottle
   }
 }

--- a/src/platforms/twitch/index.js
+++ b/src/platforms/twitch/index.js
@@ -1,6 +1,7 @@
 const TMI = require('tmi.js');
 const ShenaniBot = require('../../bot/index');
 const env = require('../../config/config');
+const pb = require('@madelsberger/pausebuffer');
 
 const options = {
   options: {
@@ -16,7 +17,8 @@ const options = {
   channels: [env.auth.channel]
 };
 
-const client = TMI.Client(options);
+const _client = TMI.Client(options);
+const client = env.config.useThrottle ? pb.wrap(_client) : _client;
 const shenanibot = new ShenaniBot(env);
 
 (async function main() {


### PR DESCRIPTION
This is a basic integration with a throttling library I wrote a while back for tmi.js clients, to ensure that even if chat were very active (or in theory even if someone were trying to manipulate the bot to cause trouble) the bot wouldn't spam chat - particularly not heavily enough to get disconnected.  You can find info about the throttling library (including the full docs and source code) at https://github.com/madelsberger/pausebuffer

For now, this just provides a single option (use throttling or no), and sets up the default configuration if throttling is enabled.  That means no more than 19 messages every 35 seconds, and 1.5s between messages.

For streamers that use a mod account to run their bot, this may be overkill; though throttling may still be advisable if they run multiple bots, as lack of throttle coordination is one of the big reasons I prefer not to use more stand-alone bots than I need