### PR TITLE
Dev

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -165,7 +165,7 @@ class ShenaniBot {
       const level = this.queue[i];
 
       if (level.levelId === levelId) {
-        if (level.submittedBy === username) {
+        if (level.submittedBy === username || this.streamer === username) {
           if (i === 0) {
             response = "You can't remove the current level from the queue!";
             return response;
@@ -173,7 +173,7 @@ class ShenaniBot {
           
           this._removeFromQueue(i);
           response = `${level.levelName}@${level.levelId} was removed from the queue!`;
-          this.levels[levelId] = null;
+          this.levels[levelId] = (username === this.streamer) ? `was removed by ${username}; it can't be re-added` : null;
           return response;
         } else {
           response = "You can't remove a level from the queue that you didn't submit!";

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -135,15 +135,17 @@ class ShenaniBot {
         username
       );
       this.queue.push(level);
-      if (this.queue.length === 1) {
-        this._playLevel();
-      }
 
       user.levelsSubmitted++;
       user.permit = (username === this.streamer);
 
       response = `${level.levelName}@${level.levelId} was added! Your level is #${this.queue.length} in queue.`;
       response = this.options.levelLimit > 0 ? `${response} Submission ${user.levelsSubmitted}/${this.options.levelLimit}` : response;
+
+      if (this.queue.length === 1) {
+        response = `${response}\n${this._playLevel()}`;
+      }
+
       this.levels[levelInfo[0].levelId] = "is already in the queue";
       return response;
     } catch (error) {

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -9,6 +9,7 @@ class ShenaniBot {
     this.queue = [];
     this.queueOpen = true;
     this.users = {};
+    this.levels = {};
   }
 
   async command(command, username) {
@@ -119,13 +120,10 @@ class ShenaniBot {
       return response;
     }
 
-    for (let i = 0; i < this.queue.length; i++) {
-      const level = this.queue[i];
-
-      if (level.levelId === levelId) {
-        response = "That level is already in the queue!";
-        return response;
-      }
+    const reason = this.levels[levelId];
+    if (reason) {
+      response = `That level ${reason}!`;
+      return response;
     }
 
     let levelInfo = await this.rce.levelhead.levels.search({ levelIds: levelId, includeAliases: true }, { doNotUseKey: true });
@@ -146,6 +144,7 @@ class ShenaniBot {
 
       response = `${level.levelName}@${level.levelId} was added! Your level is #${this.queue.length} in queue.`;
       response = this.options.levelLimit > 0 ? `${response} Submission ${user.levelsSubmitted}/${this.options.levelLimit}` : response;
+      this.levels[levelInfo[0].levelId] = "is already in the queue";
       return response;
     } catch (error) {
       console.error(error);
@@ -172,6 +171,7 @@ class ShenaniBot {
           
           this._removeFromQueue(i);
           response = `${level.levelName}@${level.levelId} was removed from the queue!`;
+          this.levels[levelId] = null;
           return response;
         } else {
           response = "You can't remove a level from the queue that you didn't submit!";
@@ -228,6 +228,7 @@ class ShenaniBot {
     }
 
     this.rce.levelhead.bookmarks.remove(this.queue[0].levelId);
+    this.levels[this.queue[0].levelId] = "was already played";
     this._removeFromQueue(0);
     
     return {

--- a/src/platforms/twitch/index.js
+++ b/src/platforms/twitch/index.js
@@ -35,7 +35,9 @@ const shenanibot = new ShenaniBot(env);
 
     (async function command() {
       let response = await shenanibot.command(message, user.username);
-      client.say(env.auth.channel, response);
+      for (const message of response.split('\n')) {
+        client.say(env.auth.channel, message);
+      }
     })();
   });
 })();


### PR DESCRIPTION
This collects a number of minor improvements:
- bot will remember if a level has been played, so the same level can't be resubmitted
- added "now playing" message when 1st level is added to the queue
- streamer can remove any level from the queue (except the 1st; still just use !next for that)