### PR TITLE
Feature/mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The bot stores a list of viewer-submitted levelcodes for you to play, and automa
 `!permit [user name]` : Allows a user to add one level to the queue even if it is closed or they have reached the submission limit
 `!next` : Moves the queue forward a level  
 `!random` : Chooses a random level from the queue and puts it at the front of the queue to play
+`!mark` : Place a marker in the queue.  Markers do two things:  First, they occupy a spot in the queue to allow for situations with no "now playing" level.  For example, if you don't want the first submitted level to immediately move to "now playing", you can insert a marker before opening the queue.  Second, `!random` will only consider levels up to the next marker.  (That is, if the top of the queue is a marker, it will be discarded as normal; but then a level will be chosen from those that are before the subsequent marker in the queue.)
   
 **Viewer Commands**  
 `!add [level code]` : Adds a level to the level queue  

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -165,7 +165,7 @@ class ShenaniBot {
       const level = this.queue[i];
 
       if (level.levelId === levelId) {
-        if (level.submittedBy === username) {
+        if (level.submittedBy === username || this.streamer === username) {
           if (i === 0) {
             response = "You can't remove the current level from the queue!";
             return response;
@@ -173,7 +173,7 @@ class ShenaniBot {
           
           this._removeFromQueue(i);
           response = `${level.levelName}@${level.levelId} was removed from the queue!`;
-          this.levels[levelId] = null;
+          this.levels[levelId] = (username === this.streamer) ? `was removed by ${username}; it can't be re-added` : null;
           return response;
         } else {
           response = "You can't remove a level from the queue that you didn't submit!";

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -135,15 +135,17 @@ class ShenaniBot {
         username
       );
       this.queue.push(level);
-      if (this.queue.length === 1) {
-        this._playLevel();
-      }
 
       user.levelsSubmitted++;
       user.permit = (username === this.streamer);
 
       response = `${level.levelName}@${level.levelId} was added! Your level is #${this.queue.length} in queue.`;
       response = this.options.levelLimit > 0 ? `${response} Submission ${user.levelsSubmitted}/${this.options.levelLimit}` : response;
+
+      if (this.queue.length === 1) {
+        response = `${response}\n${this._playLevel()}`;
+      }
+
       this.levels[levelInfo[0].levelId] = "is already in the queue";
       return response;
     } catch (error) {

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -9,6 +9,7 @@ class ShenaniBot {
     this.queue = [];
     this.queueOpen = true;
     this.users = {};
+    this.levels = {};
   }
 
   async command(command, username) {
@@ -119,13 +120,10 @@ class ShenaniBot {
       return response;
     }
 
-    for (let i = 0; i < this.queue.length; i++) {
-      const level = this.queue[i];
-
-      if (level.levelId === levelId) {
-        response = "That level is already in the queue!";
-        return response;
-      }
+    const reason = this.levels[levelId];
+    if (reason) {
+      response = `That level ${reason}!`;
+      return response;
     }
 
     let levelInfo = await this.rce.levelhead.levels.search({ levelIds: levelId, includeAliases: true }, { doNotUseKey: true });
@@ -146,6 +144,7 @@ class ShenaniBot {
 
       response = `${level.levelName}@${level.levelId} was added! Your level is #${this.queue.length} in queue.`;
       response = this.options.levelLimit > 0 ? `${response} Submission ${user.levelsSubmitted}/${this.options.levelLimit}` : response;
+      this.levels[levelInfo[0].levelId] = "is already in the queue";
       return response;
     } catch (error) {
       console.error(error);
@@ -172,6 +171,7 @@ class ShenaniBot {
           
           this._removeFromQueue(i);
           response = `${level.levelName}@${level.levelId} was removed from the queue!`;
+          this.levels[levelId] = null;
           return response;
         } else {
           response = "You can't remove a level from the queue that you didn't submit!";
@@ -228,6 +228,7 @@ class ShenaniBot {
     }
 
     this.rce.levelhead.bookmarks.remove(this.queue[0].levelId);
+    this.levels[this.queue[0].levelId] = "was already played";
     this._removeFromQueue(0);
     
     return {

--- a/src/platforms/twitch/index.js
+++ b/src/platforms/twitch/index.js
@@ -35,7 +35,9 @@ const shenanibot = new ShenaniBot(env);
 
     (async function command() {
       let response = await shenanibot.command(message, user.username);
-      client.say(env.auth.channel, response);
+      for (const message of response.split('\n')) {
+        client.say(env.auth.channel, message);
+      }
     })();
   });
 })();


### PR DESCRIPTION
Add the !mark command - a streamer command that adds a "marker" to the queue.  A marker does two things:

1) It occupies a spot in the queue (but is not associated with any level); so when a marker is at the top of the queue, there is no level being "currently played".

- The streamer can place a marker at the top of the queue before accepting levels, so that the first level doesn't immediately go into "now playing" status.  This doesn't matter much, but if they plan to play levels in random order it does prevent the first submission being automatically first played.
- If the streamer plans to do something "outside the queue" at some point in the stream, they can use this so the place for that activity is held in the queue.

2) It delimits "batches" of levels, so that !random will only pull from the first batch.  For example, if the streamer wants to play levels submitted at the start of stream in random order, then after those levels are !added the streamer can place a marker.  !random will choose from those levels until they are exhausted, even if more levels are added to the queue