### PR TITLE
fix !random calculation

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -91,7 +91,7 @@ class ShenaniBot {
   randomLevel() {
     let {empty, response} = this._dequeueLevel();
     if (!empty) {
-      let index = Math.round(Math.random() * (this.queue.length - 1));
+      let index = Math.floor(Math.random() * this.queue.length);
       let randomLevel = this.queue[index];
       this.queue.splice(index, 1)
       this.queue.unshift(randomLevel);


### PR DESCRIPTION
The way the random level is chosen was biased against the first and last levels in the queue.  Switched to an unbiased calculation.

Details:

Math.random() produces a value R such that 0 <= R < 1

The old calculation multiplied that by (L - 1), where L is the queue length, and rounded the result.  So for example, given a queue with 3 levels, (L - 1) = 2 so this produces a number 0 <= 2 * R < 2

By rounding that value, you get an index value between 0 and 2 (which is correct), but you only get 0 if 2*R < 0.5 (R < 0.25 gives a 25% chance) and you only get 2 if 2*R >= 1.5 (R >= 0.75 gives a 25% chance), while the rest of the time you get 1 (0.25 <= R < .75 gives a 50% chance).

The new calculation multiples R by L instead of (L-1), and it uses Math.floor() to convert that result into an index.  So again for L = 3, this produces a number 0 <= 3 * R < 3

The floor is 0 if 0 <= 3R < 1 (0 <= R < 1/3 gives a 1 in 3 chance), 1 if 1 <= 3R < 2 (1/3 <= R < 2/3 gives a 1 in 3 chance), and 2 if 2 <= 3R < 3 (2/3 <= R < 1 gives a 1/3 chance)